### PR TITLE
Embed stream iframe

### DIFF
--- a/client/src/pages/LiveVideoFeed.jsx
+++ b/client/src/pages/LiveVideoFeed.jsx
@@ -5,6 +5,7 @@ const LiveVideoFeed = () => {
         <div>
             <h2>Live Video Feed</h2>
             <p>Will display what the drone is seeing</p>
+            <iframe width="1000" height="630" src="https://www.youtube.com/embed/IMdeVBKfhFk?si=sJqonRsivKd2-fZo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
         </div>
     );
 };


### PR DESCRIPTION
So the OBS websocket concept is a no go. Apparently that feature only allows you to control the stream from the app, not actually watch it. So now we have to bounce the video like so:

Drone App on Phone -> Discord Video Call to Laptop -> Stream on OBS -> Youtube Stream -> Iframe Embed on App

We'll have to update the iframe every time we start a new stream, I suppose.